### PR TITLE
add option to preserve linebreaks while content is collapsed #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ export default Home;
 | `expandOnly` | `bool` | no | defaults to `false` => hide see less option similar to a linkedIn post
 | `onExpand` | `func` | no | optional callback executed when expanded
 | `onCollapse` | `func` | no | optional callback executed when collapsed
+| `preserveLinebreaks` | `bool` | no | defaults to `false` => preserves `\n` in the content while in the collapsed state 
 
 Any additional props are passed down to underlying `Text` component.
 

--- a/example/src/ReadMore.js
+++ b/example/src/ReadMore.js
@@ -47,6 +47,7 @@ const ReadMore = ({
   expandOnly,
   seeMoreOverlapCount,
   debounceSeeMoreCalc,
+  preserveLinebreaks,
   ...restProps
 }) => {
   const [additionalProps, setAdditionalProps] = useState({});
@@ -82,7 +83,7 @@ const ReadMore = ({
   const [afterCollapsed, setAfterCollapsed] = useState(true);
   // copy of children with only text
   const [collapsedChildren, setCollapsedChildren] = useState(
-    childrenToTextChildren(children, TextComponent),
+    childrenToTextChildren(children, TextComponent, preserveLinebreaks),
   );
   const [measuredCollapsedChildren, setMeasuredCollapsedChildren] = useState(
     null,
@@ -202,7 +203,7 @@ const ReadMore = ({
     // go to this position and insert a line break
     let charactersToTraverse = textBreakPosition;
     let nodeFound = false;
-    const modifiedChildrenObjects = getText(children, TextComponent).map(
+    const modifiedChildrenObjects = getText(children, TextComponent, preserveLinebreaks).map(
       (_childObject) => {
         if (nodeFound) {
           return _childObject;
@@ -381,7 +382,7 @@ const ReadMore = ({
   }, [measureSeeMoreLine]);
 
   useEffect(() => {
-    const _textChildren = childrenToTextChildren(children, TextComponent);
+    const _textChildren = childrenToTextChildren(children, TextComponent, preserveLinebreaks);
     setCollapsedChildren(_textChildren);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [children]);
@@ -566,6 +567,7 @@ ReadMore.propTypes = {
   expandOnly: PropTypes.bool,
   seeMoreOverlapCount: PropTypes.number,
   debounceSeeMoreCalc: PropTypes.number,
+  preserveLinebreaks: PropTypes.bool,
 };
 
 ReadMore.defaultProps = {
@@ -586,6 +588,7 @@ ReadMore.defaultProps = {
   expandOnly: false,
   seeMoreOverlapCount: 1,
   debounceSeeMoreCalc: 300,
+  preserveLinebreaks: false,
 };
 
 export default memo(ReadMore);

--- a/example/src/ReadMore.js
+++ b/example/src/ReadMore.js
@@ -396,7 +396,6 @@ const ReadMore = ({
   }, [truncatedLineOfImpact]);
 
   useEffect(() => {
-    console.log('padding', truncatedLineOfImpactWidth, seeMoreWidth, textWidth);
     if (!truncatedLineOfImpactWidth || !seeMoreWidth || !textWidth) {
       setSeeMoreRightPadding(0);
       return;

--- a/example/src/helper.js
+++ b/example/src/helper.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const getStringChild = (child) => {
-  const content = child?.split('\n').join('');
+const getStringChild = (child, preserveLinebreaks = false) => {
+  const content = preserveLinebreaks ? child : child?.split('\n').join(' ');
   return {
     type: 'string',
     content,
@@ -9,8 +9,8 @@ const getStringChild = (child) => {
   };
 };
 
-const getTextChild = (child) => {
-  const content = child.props.children?.split('\n').join('');
+const getTextChild = (child, preserveLinebreaks = false) => {
+  const content = preserveLinebreaks ? child.props.children : child.props.children?.split('\n').join(' ');
   return {
     type: child?.type?.displayName,
     content,
@@ -18,9 +18,9 @@ const getTextChild = (child) => {
   };
 };
 
-export const getText = (children, TextComponent) => {
+export const getText = (children, TextComponent, preserveLinebreaks) => {
   if (typeof children === 'string') {
-    return [getStringChild(children)];
+    return [getStringChild(children, preserveLinebreaks)];
   }
 
   if (Array.isArray(children)) {
@@ -33,7 +33,7 @@ export const getText = (children, TextComponent) => {
       })
       .map((_child) => {
         if (typeof _child === 'string') {
-          return getStringChild(_child);
+          return getStringChild(_child, preserveLinebreaks);
         }
 
         return getTextChild(_child);
@@ -43,13 +43,13 @@ export const getText = (children, TextComponent) => {
   return null;
 };
 
-export const childrenToText = (children, TextComponent) => {
-  const _textChildren = getText(children, TextComponent);
+export const childrenToText = (children, TextComponent, preserveLinebreaks) => {
+  const _textChildren = getText(children, TextComponent, preserveLinebreaks);
   return _textChildren.map((_t) => _t.content).join(' ');
 };
 
-export const childrenToTextChildren = (children, TextComponent) => {
-  const _textChildren = getText(children, TextComponent);
+export const childrenToTextChildren = (children, TextComponent, preserveLinebreaks) => {
+  const _textChildren = getText(children, TextComponent, preserveLinebreaks);
   return _textChildren.map((_t) => _t.child);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fawazahmed/react-native-read-more",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple react native library to show large blocks of text in a condensed manner with the ability to collapse and expand.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added a parameter to keep the `\n` while the content is collapsed.

Also, if the linebreaks shouldn't be shown, the linebreaks are replaced by a whitespace instead of an empty string