### PR TITLE
fix #61: add collapsed prop for toggling state

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ export default Home;
 | `debug` | `bool` | no | print debug logs to examine
 | `seeMoreContainerStyleSecondary` | `object` | no | Incase of text overlap, pass { position: 'relative' } see [issue](https://github.com/fawaz-ahmed/react-native-read-more/issues/52) (not recommended)
 | `onSeeMoreBlocked` | `func` | no | when a function is passed, will disable the default See More toggling and use the custom callback instead. Useful to do things like open a modal instead of expanding text when See More is pressed.
+| `collapsed` | `bool` | no | a property to set the collapsed state of the text component. Can be used toggle the collapsed state from outside.
 
 Any additional props are passed down to underlying `Text` component.
 

--- a/example/src/ReadMore.js
+++ b/example/src/ReadMore.js
@@ -54,6 +54,7 @@ const ReadMore = ({
   seeMoreContainerStyleSecondary,
   onSeeMoreBlocked,
   debug,
+  collapsed: collapsedProp,
   ...restProps
 }) => {
   const [additionalProps, setAdditionalProps] = useState({});
@@ -80,7 +81,7 @@ const ReadMore = ({
   const [isReady, setIsReady] = useState(false);
   // logic decisioning params
   const [seeMore, setSeeMore] = useState(false);
-  const [collapsed, setCollapsed] = useState(true);
+  const [collapsed, setCollapsed] = useState(collapsedProp);
   const [afterCollapsed, setAfterCollapsed] = useState(true);
   // copy of children with only text
   const [collapsedChildren, setCollapsedChildren] = useState(null);
@@ -450,6 +451,10 @@ const ReadMore = ({
   }, [collapsed]);
 
   useEffect(() => {
+    toggle();
+  }, [collapsedProp, toggle]);
+
+  useEffect(() => {
     const handle = setTimeout(() => {
       // to commence measurement chain
       // we should mount component 1
@@ -731,6 +736,7 @@ ReadMore.propTypes = {
   seeMoreContainerStyleSecondary: PropTypes.object,
   onSeeMoreBlocked: PropTypes.func,
   debug: PropTypes.bool,
+  collapsed: PropTypes.bool,
 };
 
 ReadMore.defaultProps = {
@@ -757,6 +763,7 @@ ReadMore.defaultProps = {
   seeMoreContainerStyleSecondary: {},
   onSeeMoreBlocked: undefined,
   debug: false,
+  collapsed: true,
 };
 
 export default memo(ReadMore);


### PR DESCRIPTION
This pr adds a collapsed prop, making it possible to toggle the state of the component from outside. This could be useful if we want to collapse or expand the component upon clicking on the text and not the See more|See less section. 

It could be done like this:

```javascript
const App = () => {
  const [collapsed, setCollapsed] = React.useState(true);
  return (
    <SafeAreaView style={styles.safe}>
      <View style={styles.root}>
        <ReadMore
          numberOfLines={3}
          style={styles.textStyle}
          collapsed={collapsed}
          onPress={() => {
            setCollapsed(!collapsed);
          }}>
          {
            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
          }
        </ReadMore>
      </View>
    </SafeAreaView>
  );
};
```

In action, it could look like this:


https://user-images.githubusercontent.com/557246/200939012-e79be840-ea9b-4237-b486-713b680a6609.mov

