### PR TITLE
Fix type of customTextComponent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface ReadMoreProps extends TextProps {
     seeMoreText?: string;
     seeLessText?: string;
     animate?: boolean;
-    customTextComponent?: React.ReactNode;
+    customTextComponent?: React.FC<TextProps>;
     ellipsis?: string;
     onExpand?: () => void;
     onCollapse?: () => void;


### PR DESCRIPTION
The type of customTextComponent is incorrect, if you pass in a ReactNode, the library throws an error.

ReactNode is `<Text>Hello</Text>`

React.FC<TextProps> is `Text`